### PR TITLE
Fix a bug.

### DIFF
--- a/pymeflib/tree2.py
+++ b/pymeflib/tree2.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import warnings
 from pathlib import PurePath, PurePosixPath, PureWindowsPath
-from typing import Callable, Type
+from typing import Callable, Type, Union
 from logging import getLogger, NullHandler, Logger
 
 branch_str = '|__ '
 branch_str2 = '|   '
 
 GC = Callable[[PurePath], tuple[list[str], list[str]]]
-AddInfo = Callable[[str | PurePath], list[str]]
-PPath = Type[PurePath] | Type[PurePosixPath] | Type[PureWindowsPath]
+AddInfo = Callable[[Union[str, PurePath]], list[str]]
+PPath = Union[Type[PurePath], Type[PurePosixPath], Type[PureWindowsPath]]
 
 
 class TreeViewer():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymeflib"
-version = "1.0.20240926"
+version = "1.0.20240928"
 description = "MeF0504 personal python library"
 license = {file = "LICENSE"}
 authors = [{name = "MeF0504"}]


### PR DESCRIPTION
type annotation using pipe works in Python 3.9 only after ":".